### PR TITLE
Update firehose client to accept start param and remove keep-alive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 FIREHOSE_BASE_URL="data.reddit.com"
 FIREHOSE_TOKEN="token_here"
 FIREHOSE_SUBSCRIPTION_ID="subscription_id_here"
+# START can either be timestamp or redis stream id
+# Redis stream id should adhere to regex regexp.MustCompile(`\d{13}-\d+`)
+# Timestamp should adhere to ISO 8601 date and time format
+START=""

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Set the value of `FIREHOSE_TOKEN` to the auth token you received.
 
 Set the value of `FIREHOSE_SUBSCRIPTION_ID` to the subscription ID you received.
 
+Set the value of `START` to either a timestamp (can be any timestamp in ISO 8601 date and time format within the last 24 hours from current timestamp) or Id of the last event which was received in firehose. If the value is an empty string, it ll start streaming data from the current timestamp.
+
 ## Usage
 
 `npm start`

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ require('dotenv').config();
 
 const FIREHOSE_AUTH_KEY = 'x-firehose-key';
 
-program.option('--keep-alive');
-
 program.parse();
 
 async function run() {
@@ -53,7 +51,6 @@ async function listen() {
 
 async function initStream() {
   const httpsAgent = new https.Agent({
-    keepAlive: true,
     rejectUnauthorized: true,
   });
 
@@ -64,9 +61,7 @@ async function initStream() {
     data: {
       // This designates which subscription will be used to filter data to the firehose
       subscriptionId: process.env.FIREHOSE_SUBSCRIPTION_ID,
-    },
-    params: {
-      keep_alive: program.opts().keepAlive,
+      start: process.env.START,
     },
     // This header token is your unique authentication token for the firehose
     headers: { [FIREHOSE_AUTH_KEY]: process.env.FIREHOSE_TOKEN },


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
## 💸 TL;DR
- Adding start option to the client. Start can take in a timestamp or id of the last event received. If it is empty, it ll start streaming from the current timestamp
- Removed keep alive as it is available by default 


## 🧪 Testing Steps / Validation
Tested by `npm start` and fetching in a token id and subscription id 